### PR TITLE
Add support for binary and hex files

### DIFF
--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -40,7 +40,13 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
         }
         starter.setPacketsReceiptNotificationsValue(1);
         starter.setUnsafeExperimentalButtonlessServiceInSecureDfuEnabled(true);
-        starter.setZip(filePath);
+
+        if (filePath.endsWith(".bin") || filePath.endsWith(".hex")) {
+            starter.setBinOrHex(DfuBaseService.TYPE_APPLICATION, filePath).setInitFile(null, null);
+        } else {
+            starter.setZip(filePath);
+        }
+
         final DfuServiceController controller = starter.start(this.reactContext, DfuService.class);
     }
 

--- a/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
+++ b/android/src/main/java/com/pilloxa/dfu/RNNordicDfuModule.java
@@ -41,7 +41,7 @@ public class RNNordicDfuModule extends ReactContextBaseJavaModule implements Lif
         starter.setPacketsReceiptNotificationsValue(1);
         starter.setUnsafeExperimentalButtonlessServiceInSecureDfuEnabled(true);
 
-        if (filePath.endsWith(".bin") || filePath.endsWith(".hex")) {
+        if (filePath.toLowerCase().endsWith(".bin") || filePath.toLowerCase().endsWith(".hex")) {
             starter.setBinOrHex(DfuBaseService.TYPE_APPLICATION, filePath).setInitFile(null, null);
         } else {
             starter.setZip(filePath);

--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -217,10 +217,17 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
         reject(@"unable_to_find_device", @"Could not find device with deviceAddress", nil);
       } else {
         CBPeripheral * peripheral = [peripherals objectAtIndex:0];
+        DFUFirmware * firmware;
 
         NSURL * url = [NSURL URLWithString:filePath];
+        NSString * extension = [url pathExtension];
 
-        DFUFirmware * firmware = [[DFUFirmware alloc] initWithUrlToZipFile:url];
+        if (([extension caseInsensitiveCompare:@"bin"] == NSOrderedSame) ||
+              ([extension caseInsensitiveCompare:@"hex"] == NSOrderedSame)) {
+            firmware = [[DFUFirmware alloc] initWithUrlToBinOrHexFile:url urlToDatFile:nil type:4];
+        } else {
+            firmware = [[DFUFirmware alloc] initWithUrlToZipFile:url];
+        }
 
         DFUServiceInitiator * initiator = [[[DFUServiceInitiator alloc]
                                             initWithCentralManager:centralManager


### PR DESCRIPTION
In some cases it is more convinient to use a binary or hex file directly instead of using a zip file.

We can check the extention and do the appropriate action.