### PR TITLE
Add android 14 support

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -38,6 +38,6 @@ repositories {
 
 dependencies {
     implementation 'com.facebook.react:react-native:+'
-    implementation 'no.nordicsemi.android:dfu:2.3.0'
+    implementation 'no.nordicsemi.android:dfu:2.4.2'
 }
 

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,8 +1,13 @@
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.pilloxa.dfu">
+
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE_CONNECTED_DEVICE" />
     <application>
-        <service android:name=".DfuService"/>
+        <service android:name=".DfuService"
+          android:foregroundServiceType="connectedDevice"
+          android:enabled="true"
+          android:exported="false" />
     </application>
 
 </manifest>


### PR DESCRIPTION
- [x] Fix "Starting FGS without a type" - https://github.com/NordicSemiconductor/Android-DFU-Library/issues/423
- [x] Fix "One of RECEIVER_EXPORTED or RECEIVER_NOT_EXPORTED should be specified" by updating Android-DFU-Library

Relates to issue #17 