### PR TITLE
Fix: Resolved Obj-C type errors for RN 0.76+

### DIFF
--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -185,8 +185,8 @@ didOccurWithMessage:(NSString * _Nonnull)message
 RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
                   deviceName:(NSString *)deviceName
                   filePath:(NSString *)filePath
-                  packetReceiptNotificationParameter:(NSInteger *)packetReceiptNotificationParameter
-                  alternativeAdvertisingNameEnabled:(BOOL *)alternativeAdvertisingNameEnabled
+                  packetReceiptNotificationParameter:(NSInteger)packetReceiptNotificationParameter
+                  alternativeAdvertisingNameEnabled:(BOOL)alternativeAdvertisingNameEnabled
                   resolver:(RCTPromiseResolveBlock)resolve
                   rejecter:(RCTPromiseRejectBlock)reject)
 {


### PR DESCRIPTION
Fix for #22 

This resolves the following error on RN 0.76+

```
 RNNordicDfu.startDFU(): Error while converting JavaScript argument 3 to Objective C type NSInteger. Objective C type NSInteger is unsupported.
```

The error occurs because the method signature has incorrect parameter types. For `packetReceiptNotificationParameter`, it's declared as `NSInteger *` (pointer) when it should be just `NSInteger` (primitive type). Similarly, `alternativeAdvertisingNameEnabled` should be `BOOL` instead of `BOOL *`.