### PR TITLE
Remove iOS 13 workaround for DFU packet

### DIFF
--- a/ios/RNNordicDfu.m
+++ b/ios/RNNordicDfu.m
@@ -243,10 +243,7 @@ RCT_EXPORT_METHOD(startDFU:(NSString *)deviceAddress
             initiator.packetReceiptNotificationParameter = packetReceiptNotificationParameter;
             initiator.alternativeAdvertisingNameEnabled = alternativeAdvertisingNameEnabled;
 
-            // Change for iOS 13
-            initiator.packetReceiptNotificationParameter = 1; //Rate limit the DFU using PRN.
             [NSThread sleepForTimeInterval: 2]; //Work around for being stuck in iOS 13
-            // End change for iOS 13
 
             DFUServiceController * controller = [initiator start];
             


### PR DESCRIPTION
Removed workaround for iOS 13 regarding packet receipt notification parameter.